### PR TITLE
Add trailing newline to version file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "src/saltext/helm/version.py"
-write_to_template = "__version__ = \"{version}\""
+write_to_template = "__version__ = \"{version}\"\n"
 
 [project]
 name = "saltext.helm"


### PR DESCRIPTION
Pylint would complain during development:

```
src/saltext/helm/version.py:1:0: C0304: Final newline missing (missing-final-newline)
src/saltext/helm/version.py:1:0: C0328: Unexpected line ending format. There is 'CRLF' while it should be 'LF'. (unexpected-line-ending-format)
```