### PR TITLE
Remove pylint suggestion-mode

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -104,10 +104,6 @@ recursive=no
 # source root.
 source-roots=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no


### PR DESCRIPTION
The option no longer exists, causing pylint to emit a warning:

```
.pylintrc:1:0: E0015: Unrecognized option found: suggestion-mode (unrecognized-option)
```